### PR TITLE
[feat] add alpha numeric cnpj support and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,14 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-      - run: npm install
+
+      - run: npm ci
       - run: npm run lint
       - run: npm test --if-present
       - run: npm run build --if-present

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,23 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [main]
+    types: [completed]
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 jobs:
   publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,24 +31,21 @@ jobs:
 
       - run: npm ci
 
-      - name: Ensure clean git tree
-        run: |
-          git status --porcelain
-          test -z "$(git status --porcelain)"
-
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version + tag
-        run: 'npm version patch -m "chore(release): v%s [skip ci]"'
+        run: |
+          npm version patch -m "chore(release): v%s"
 
       - name: Push commit + tags
-        run: git push --follow-tags
+        run: git push --follow-tags origin HEAD:main
 
-      # Build só depois da versão (evita “dirty” antes do npm version)
       - run: npm run build --if-present
 
       - name: Publish to npm
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/__tests__/cnpj.test.ts
+++ b/src/__tests__/cnpj.test.ts
@@ -6,8 +6,31 @@ describe("CNPJ Validation", () => {
     expect(Cnpj.isValid("12.345.678/0001-95")).toBe(true);
   });
 
+  it("should validate a correct CNPJ without formatting", () => {
+    expect(Cnpj.isValid("12345678000195")).toBe(true);
+  });
+
+  it("should validate a correct alphanumeric CNPJ", () => {
+    expect(Cnpj.isValid("3K.4ZV.GKB/0001-10")).toBe(true);
+    expect(Cnpj.isValid("3K4ZVGKB000110")).toBe(true);
+    expect(Cnpj.isValid("TA.JDY.N97/0001-72")).toBe(true);
+    expect(Cnpj.isValid("VZ.ZNH.Z91/0001-06")).toBe(true);
+  });
+
   it("should invalidate an incorrect CNPJ", () => {
     expect(Cnpj.isValid("12.345.678/0001-96")).toBe(false);
+  });
+
+  it("should invalidate an empty CNPJ", () => {
+    expect(Cnpj.isValid("")).toBe(false);
+  });
+
+  it("should invalidate an incorrect alphanumeric CNPJ", () => {
+    expect(Cnpj.isValid("3K.4ZV.GKB/0001-11")).toBe(false);
+  });
+
+  it("should format a alphanumeric CNPJ correctly", () => {
+    expect(Cnpj.format("3K4ZVGKB000110")).toBe("3K.4ZV.GKB/0001-10");
   });
 
   it("should format a CNPJ correctly", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,12 @@ export interface IParser<T> {
  * Implementa as interfaces de validação, formatação e parsing.
  * @param T - Tipo do documento a ser manipulado.
  * @interface IDocumentHandler
- * @extends {IValidator<T>}
- * @extends {IFormatter<T>}
- * @extends {IParser<T>}
  */
-export interface IDocumentHandler<T>
-  extends IValidator<T>,
-    IFormatter<T>,
-    IParser<T> {}
+export interface IDocumentHandler<T> {
+  isValid?: (input: T) => boolean;
+  format?: (input: T) => string;
+  parse?: (input: T) => string;
+}
 
 export { Cpf } from "./cpf";
 export { Cnpj } from "./cnpj";

--- a/src/utils/cleanAlphaNumeric.ts
+++ b/src/utils/cleanAlphaNumeric.ts
@@ -1,0 +1,5 @@
+const cleanAlphaNumeric = (str: string) => {
+  return str.toUpperCase().replace(/[^A-Z0-9]/g, "");
+};
+
+export default cleanAlphaNumeric;


### PR DESCRIPTION
This pull request introduces significant improvements to CNPJ (Brazilian company identifier) validation, formatting, and parsing, including support for alphanumeric CNPJs, and refactors the document handler interface for better flexibility. It also updates CI/CD workflows for improved reliability and security.

### CNPJ validation and formatting enhancements

* Added support for alphanumeric CNPJs in validation, formatting, and parsing, including new test cases to cover these scenarios. (`src/cnpj.ts`, `src/__tests__/cnpj.test.ts`) [[1]](diffhunk://#diff-5d6b65903ba99fce54ac3524b0bb7d3104501a9a95d0664c9e696a538d88494bL50-R71) [[2]](diffhunk://#diff-5d6b65903ba99fce54ac3524b0bb7d3104501a9a95d0664c9e696a538d88494bL71-R85) [[3]](diffhunk://#diff-5d6b65903ba99fce54ac3524b0bb7d3104501a9a95d0664c9e696a538d88494bL86-R96) [[4]](diffhunk://#diff-3e26ca01be7285849c8b50e718831e7f2f120177b9febe68c12a27418ea566a9R9-R35)
* Introduced the new utility function `cleanAlphaNumeric` to normalize CNPJ strings, replacing the previous `cleanString` implementation. (`src/utils/cleanAlphaNumeric.ts`, `src/cnpj.ts`) [[1]](diffhunk://#diff-124b08158f9dbb3f5b02c2c63ebdd360bd1cf954101a281251fc4dafa4c404e1R1-R5) [[2]](diffhunk://#diff-5d6b65903ba99fce54ac3524b0bb7d3104501a9a95d0664c9e696a538d88494bL2-R12)
* Improved digit calculation logic to support both numeric and alphanumeric CNPJs, using ASCII values for character-to-number conversion. (`src/cnpj.ts`)

### Refactoring and interface changes

* Refactored the `IDocumentHandler` interface to make `isValid`, `format`, and `parse` optional, improving extensibility and type safety. (`src/index.ts`)

### CI/CD workflow improvements

* Updated GitHub Actions to use the latest versions and switched to `npm ci` for cleaner installs. (`.github/workflows/ci.yml`)
* Enhanced release workflow: now triggers only after successful CI runs, adds concurrency control, pushes tags directly to `main`, and securely publishes to npm using a token. (`.github/workflows/release.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R20) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-R51)